### PR TITLE
👨‍✈️️ Add lite_admin membership

### DIFF
--- a/api/controllers/groups/admin.ts
+++ b/api/controllers/groups/admin.ts
@@ -5,11 +5,9 @@ import { getRepository } from 'typeorm';
 import { MusicianGroup } from '../../entity';
 import type core from 'express-serve-static-core';
 import type { Request } from 'express';
-import type { FindConditions } from 'typeorm';
 
 type AddGroupLiteAdmin = operations['addGroupLiteAdmin'];
 type RemoveGroupLiteAdmin = operations['removeGroupLiteAdmin'];
-type TransferGroupAdmin = operations['transferGroupAdmin'];
 
 export const addGroupLiteAdmin = async (
   req: Request<
@@ -143,89 +141,6 @@ export const removeGroupLiteAdmin = async (
     musicianToRemoveLiteAdmin.membership = 'member';
 
     await musicianGroupRepository.save(musicianToRemoveLiteAdmin);
-
-    return res.sendStatus(204);
-  } catch (err) {
-    console.log(err);
-    return res.status(500).json({ msg: 'E_SERVER_ERROR' });
-  }
-};
-
-export const transferGroupAdmin = async (
-  req: Request<
-    getPathParams<TransferGroupAdmin>,
-    getResponsesBody<TransferGroupAdmin>,
-    {},
-    {}
-  >,
-  res: core.Response<
-    getResponsesBody<TransferGroupAdmin>,
-    {},
-    getHTTPCode<TransferGroupAdmin>
-  >,
-): Promise<
-  core.Response<
-    getResponsesBody<TransferGroupAdmin>,
-    {},
-    getHTTPCode<TransferGroupAdmin>
-  >
-> => {
-  try {
-    const musicianGroupRepository = getRepository(MusicianGroup);
-
-    const musicianIdToTransferAdmin = req.params.musicianId;
-    const groupId = req.params.groupId;
-
-    const admin = await musicianGroupRepository.findOne({
-      where: {
-        musician: {
-          id: req.userId,
-        },
-        group: {
-          id: groupId,
-        },
-        membership: 'admin',
-      },
-      relations: ['musician', 'group'],
-    });
-
-    if (!admin) {
-      return res.status(403).json({ msg: 'E_UNAUTHORIZED_USER' });
-    }
-
-    const query: FindConditions<MusicianGroup> = {
-      musician: {
-        id: musicianIdToTransferAdmin,
-      },
-      group: {
-        id: groupId,
-      },
-    };
-
-    const musicianToTransferAdmin = await musicianGroupRepository.findOne({
-      where: [
-        {
-          ...query,
-          membership: 'lite_admin',
-        },
-        {
-          ...query,
-          membership: 'member',
-        },
-      ],
-      relations: ['musician', 'group'],
-    });
-
-    if (!musicianToTransferAdmin) {
-      return res
-        .status(404)
-        .json({ msg: 'E_MUSICIAN_NOT_LITE_ADMIN_OR_MEMBER' });
-    }
-
-    musicianToTransferAdmin.membership = 'admin';
-    admin.membership = 'lite_admin';
-
-    await musicianGroupRepository.save([musicianToTransferAdmin, admin]);
 
     return res.sendStatus(204);
   } catch (err) {

--- a/api/controllers/groups/groups.ts
+++ b/api/controllers/groups/groups.ts
@@ -275,7 +275,7 @@ export const modifyGroupById = async (
       },
     });
 
-    if (!(membership == 'admin')) {
+    if (!(membership == 'admin' || membership == 'lite_admin')) {
       return res.status(403).json({ msg: 'E_UNAUTHORIZED_USER' });
     }
 

--- a/api/controllers/groups/index.ts
+++ b/api/controllers/groups/index.ts
@@ -7,3 +7,5 @@ export {
 } from './groups';
 
 export { groupJoinEvent } from './groupEvents';
+
+export { addGroupLiteAdmin, removeGroupLiteAdmin } from './admin';

--- a/api/db/reset.ts
+++ b/api/db/reset.ts
@@ -126,7 +126,7 @@ export default async function reset(): Promise<void> {
     const spiritboxMusician2 = musGrouRep.create({
       musician: dorian,
       group: spiritbox,
-      membership: 'member',
+      membership: 'lite_admin',
       instruments: [guitare],
     });
 

--- a/api/db/reset.ts
+++ b/api/db/reset.ts
@@ -126,7 +126,7 @@ export default async function reset(): Promise<void> {
     const spiritboxMusician2 = musGrouRep.create({
       musician: dorian,
       group: spiritbox,
-      membership: 'lite_admin',
+      membership: 'member',
       instruments: [guitare],
     });
 

--- a/api/docs/config/components.ts
+++ b/api/docs/config/components.ts
@@ -117,7 +117,7 @@ const components: OpenAPIV3.Document['components'] = {
         },
         membership: {
           type: 'string',
-          enum: ['admin', 'member', 'declined', 'pending'],
+          enum: ['admin', 'member', 'declined', 'pending', 'lite_admin'],
         },
       },
     },

--- a/api/docs/openApiDoc.ts
+++ b/api/docs/openApiDoc.ts
@@ -659,6 +659,115 @@ const openApiDocs: OpenAPIV3.Document = {
         },
       },
     },
+    '/groups/{groupId}/admins/lite_admins/{musicianId}': {
+      post: {
+        operationId: 'addGroupLiteAdmin',
+        tags: ['groups'],
+        security: [{ BearerAuth: [] }],
+        description: 'Give a group member the lite_admin membership',
+        parameters: [
+          {
+            in: 'path',
+            name: 'groupId',
+            schema: { type: 'string' },
+            required: true,
+            description: 'The ID of the group',
+          },
+          {
+            in: 'path',
+            name: 'musicianId',
+            schema: { type: 'string' },
+            required: true,
+            description:
+              'The ID of the musician that receive lite_admin membership',
+          },
+        ],
+        responses: {
+          '204': {
+            description: 'The musician became a lite_admin',
+            content: { 'application/json': { schema: { type: 'string' } } },
+          },
+          '403': {
+            description: 'The user does not have the right',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+          '404': {
+            description: 'The musician is not a member of the group',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+          '500': {
+            description: 'Error intern server',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        operationId: 'removeGroupLiteAdmin',
+        tags: ['groups'],
+        security: [{ BearerAuth: [] }],
+        description: 'Remove a group member the lite_admin membership',
+        parameters: [
+          {
+            in: 'path',
+            name: 'groupId',
+            schema: { type: 'string' },
+            required: true,
+            description: 'The ID of the group',
+          },
+          {
+            in: 'path',
+            name: 'musicianId',
+            schema: { type: 'string' },
+            required: true,
+            description:
+              'The ID of the musician that receive lite_admin membership',
+          },
+        ],
+        responses: {
+          '204': {
+            description:
+              'The lite_admin membership has been removed from the group member',
+            content: { 'application/json': { schema: { type: 'string' } } },
+          },
+          '403': {
+            description: 'The user does not have the right',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+          '404': {
+            description: 'The musician is not a lite_admin of the group',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+          '500': {
+            description: 'Error intern server',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/httpError' },
+              },
+            },
+          },
+        },
+      },
+    },
     '/groups/event/join': {
       post: {
         operationId: 'groupJoinEvent',

--- a/api/docs/openApiDoc.ts
+++ b/api/docs/openApiDoc.ts
@@ -1637,7 +1637,7 @@ const openApiDocs: OpenAPIV3.Document = {
           },
           membership: {
             type: 'string',
-            enum: ['admin', 'member', 'declined', 'pending'],
+            enum: ['admin', 'member', 'declined', 'pending', 'lite_admin'],
           },
         },
       },

--- a/api/docs/schemas/groups/admin/lite_admin.ts
+++ b/api/docs/schemas/groups/admin/lite_admin.ts
@@ -1,0 +1,146 @@
+import { HandlerDefinition } from '@typing';
+
+const schema: HandlerDefinition = {
+  path: '/groups/{groupId}/admins/lite_admins/{musicianId}',
+  post: {
+    operationId: 'addGroupLiteAdmin',
+    tags: ['groups'],
+    security: [{ BearerAuth: [] }],
+    description: 'Give a group member the lite_admin membership',
+    parameters: [
+      {
+        in: 'path',
+        name: 'groupId',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+        description: 'The ID of the group',
+      },
+      {
+        in: 'path',
+        name: 'musicianId',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+        description:
+          'The ID of the musician that receive lite_admin membership',
+      },
+    ],
+    responses: {
+      204: {
+        description: 'The musician became a lite_admin',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      403: {
+        description: 'The user does not have the right',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+      404: {
+        description: 'The musician is not a member of the group',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+      500: {
+        description: 'Error intern server',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+    },
+  },
+  delete: {
+    operationId: 'removeGroupLiteAdmin',
+    tags: ['groups'],
+    security: [{ BearerAuth: [] }],
+    description: 'Remove a group member the lite_admin membership',
+    parameters: [
+      {
+        in: 'path',
+        name: 'groupId',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+        description: 'The ID of the group',
+      },
+      {
+        in: 'path',
+        name: 'musicianId',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+        description:
+          'The ID of the musician that receive lite_admin membership',
+      },
+    ],
+    responses: {
+      204: {
+        description:
+          'The lite_admin membership has been removed from the group member',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      403: {
+        description: 'The user does not have the right',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+      404: {
+        description: 'The musician is not a lite_admin of the group',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+      500: {
+        description: 'Error intern server',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/httpError',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export default schema;

--- a/api/entity/MusicianGroup.ts
+++ b/api/entity/MusicianGroup.ts
@@ -3,7 +3,16 @@ import { Groups } from './Groups';
 import { Instrument } from './Instrument';
 import { Musician } from './Musician';
 
-export type Membership = 'pending' | 'member' | 'admin' | 'declined';
+/**
+ * - **lite_admin** : Can modify the group and kick members
+ * - **admin** : lite_admin rights && can delete the group
+ */
+export type Membership =
+  | 'pending'
+  | 'member'
+  | 'admin'
+  | 'lite_admin'
+  | 'declined';
 
 @Entity()
 export class MusicianGroup {
@@ -21,7 +30,7 @@ export class MusicianGroup {
 
   @Column({
     type: 'enum',
-    enum: ['pending', 'member', 'admin', 'declined'],
+    enum: ['pending', 'member', 'admin', 'declined', 'lite_admin'],
     default: 'pending',
   })
   membership: Membership;

--- a/api/routes/groups.ts
+++ b/api/routes/groups.ts
@@ -12,6 +12,15 @@ router.delete('/:groupId', groupController.deleteGroupById);
 
 router.post('/event/join', groupController.groupJoinEvent);
 
+router.post(
+  '/:groupId/admins/lite_admins/:musicianId',
+  groupController.addGroupLiteAdmin,
+);
+router.delete(
+  '/:groupId/admins/lite_admins/:musicianId',
+  groupController.removeGroupLiteAdmin,
+);
+
 // router.use('/invitation', invitationRouter);
 
 export default router;

--- a/api/types/schema.ts
+++ b/api/types/schema.ts
@@ -141,7 +141,7 @@ export interface components {
     groupMember: {
       musician?: components["schemas"]["musicianMinimized"];
       instruments?: components["schemas"]["instrument"][];
-      membership?: "admin" | "member" | "declined" | "pending";
+      membership?: "admin" | "member" | "declined" | "pending" | "lite_admin";
     };
     instrument: {
       id: string;

--- a/api/types/schema.ts
+++ b/api/types/schema.ts
@@ -40,6 +40,12 @@ export interface paths {
     /** Get a list of all genres */
     get: operations["getGenres"];
   };
+  "/groups/{groupId}/admins/lite_admins/{musicianId}": {
+    /** Give a group member the lite_admin membership */
+    post: operations["addGroupLiteAdmin"];
+    /** Remove a group member the lite_admin membership */
+    delete: operations["removeGroupLiteAdmin"];
+  };
   "/groups/event/join": {
     /** A group joins an event */
     post: operations["groupJoinEvent"];
@@ -550,6 +556,80 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["genre"][];
+        };
+      };
+      /** Error intern server */
+      500: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
+        };
+      };
+    };
+  };
+  /** Give a group member the lite_admin membership */
+  addGroupLiteAdmin: {
+    parameters: {
+      path: {
+        /** The ID of the group */
+        groupId: string;
+        /** The ID of the musician that receive lite_admin membership */
+        musicianId: string;
+      };
+    };
+    responses: {
+      /** The musician became a lite_admin */
+      204: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** The user does not have the right */
+      403: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
+        };
+      };
+      /** The musician is not a member of the group */
+      404: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
+        };
+      };
+      /** Error intern server */
+      500: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
+        };
+      };
+    };
+  };
+  /** Remove a group member the lite_admin membership */
+  removeGroupLiteAdmin: {
+    parameters: {
+      path: {
+        /** The ID of the group */
+        groupId: string;
+        /** The ID of the musician that receive lite_admin membership */
+        musicianId: string;
+      };
+    };
+    responses: {
+      /** The lite_admin membership has been removed from the group member */
+      204: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** The user does not have the right */
+      403: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
+        };
+      };
+      /** The musician is not a lite_admin of the group */
+      404: {
+        content: {
+          "application/json": components["schemas"]["httpError"];
         };
       };
       /** Error intern server */

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import server from './api/server/server';
 import http from 'http';
 import createConnection from './api/db/createConnection';
 
-import reset from './api/db/reset';
+// import reset from './api/db/reset';
 
 const PORT = process.env.PORT || 8000;
 const httpApp = new http.Server(server);


### PR DESCRIPTION
# What's new ?

## Lite_admin membership
A musician can now have the `lite_admin` membership in a group ! He can actually do all the actions an `admin` can do without delete the group.

## Routes
Two more routes, one for adding `lite_admin` and one for removing `lite_admin`. Only the group `admin` can use these routes. 
Give me a feedback on the routes path if you feel it is not right !  
