### PR TITLE
User groups also return membership and instruments

### DIFF
--- a/api/controllers/profil/profil.ts
+++ b/api/controllers/profil/profil.ts
@@ -37,9 +37,7 @@ export const getUserProfil = async (
       relations: ['group', 'group.genres'],
     });
 
-    const groups = musicianGroups.map(({ group }) => group);
-
-    return res.status(200).json({ ...profil, groups });
+    return res.status(200).json({ ...profil, groups: musicianGroups });
   } catch (err) {
     next(err);
   }

--- a/api/docs/openApiDoc.ts
+++ b/api/docs/openApiDoc.ts
@@ -1433,7 +1433,28 @@ const openApiDocs: OpenAPIV3.Document = {
                         groups: {
                           type: 'array',
                           items: {
-                            $ref: '#/components/schemas/groupDescription',
+                            type: 'object',
+                            properties: {
+                              instruments: {
+                                type: 'array',
+                                items: {
+                                  $ref: '#/components/schemas/instrument',
+                                },
+                              },
+                              membership: {
+                                type: 'string',
+                                enum: [
+                                  'admin',
+                                  'member',
+                                  'declined',
+                                  'pending',
+                                  'lite_admin',
+                                ],
+                              },
+                              group: {
+                                $ref: '#/components/schemas/groupDescription',
+                              },
+                            },
                           },
                         },
                       },

--- a/api/docs/schemas/profil/profil.ts
+++ b/api/docs/schemas/profil/profil.ts
@@ -23,7 +23,26 @@ const schema: HandlerDefinition = {
                     groups: {
                       type: 'array',
                       items: {
-                        $ref: '#/components/schemas/groupDescription',
+                        type: 'object',
+                        properties: {
+                          instruments: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/instrument' },
+                          },
+                          membership: {
+                            type: 'string',
+                            enum: [
+                              'admin',
+                              'member',
+                              'declined',
+                              'pending',
+                              'lite_admin',
+                            ],
+                          },
+                          group: {
+                            $ref: '#/components/schemas/groupDescription',
+                          },
+                        },
                       },
                     },
                   },

--- a/api/types/schema.ts
+++ b/api/types/schema.ts
@@ -996,7 +996,16 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["musician"] & {
-            groups: components["schemas"]["groupDescription"][];
+            groups: {
+              instruments?: components["schemas"]["instrument"][];
+              membership?:
+                | "admin"
+                | "member"
+                | "declined"
+                | "pending"
+                | "lite_admin";
+              group?: components["schemas"]["groupDescription"];
+            }[];
           };
         };
       };


### PR DESCRIPTION
When fetch the `GET/ profil`, the `groups`  array contains this :

```ts
{
  membership :"admin",
  instruments : [
    {
      id : "id",
      name : "batterie"
    }
  ],
  group : {
    id : "id",
    ...otherInfo
  }

}
```